### PR TITLE
using evaluated url path for s3 upload path

### DIFF
--- a/dmrpp_generator/main.py
+++ b/dmrpp_generator/main.py
@@ -40,18 +40,14 @@ class DMRPPGenerator(Process):
                 break
         return buckets[bucket_type]
 
-    
-    def upload_file(self, filename):
+
+    def upload_file(self, filename, uri):
         """ Upload a local file to s3 if collection payload provided """
-        info = self.get_publish_info(filename)
-        if info is None:
-            return filename
         try:
-            return s3.upload(filename, info['s3'], extra={}) if info.get('s3', False) else None
+            return s3.upload(filename, uri, extra={})
         except Exception as e:
             self.logger.error("Error uploading file %s: %s" % (os.path.basename(os.path.basename(filename)), str(e)))
 
-    
 
     def process(self):
         """
@@ -61,29 +57,27 @@ class DMRPPGenerator(Process):
         collection = self.config.get('collection')
         buckets = self.config.get('buckets')
         granules = self.input['granules']
-        append_output = {}
         for granule in granules:
-            granule_id = granule['granuleId']
+            dmrpp_files = []
             for file_ in granule['files']:
+                if not match(f"{self.processing_regex}$", file_['filename']):
+                    continue
                 output_file_path = self.dmrpp_generate(file_['filename'])
                 if output_file_path:
-                    s3_path = output_file_path.get('s3_path')
-                    file_local_path = output_file_path.get('file_local_path')
-                    append_output[granule_id] = append_output.get(granule_id, {'files': []})
-                    append_output[granule_id]['files'].append({
-                        "bucket": self.get_bucket(file_['filename'], collection.get('files', []),buckets)['name'],
-                        "filename": s3_path,
-                        "name": os.path.basename(file_local_path),
-                        "size": os.path.getsize(file_local_path),
+                    dmrpp_file = {
+                        "name": os.path.basename(output_file_path),
                         "path": self.config.get('fileStagingDir'),
-                        "url_path": self.config.get('fileStagingDir'),
+                        "url_path": file_['url_path'],
+                        "bucket": self.get_bucket(file_['filename'], collection.get('files', []),buckets)['name'],
+                        "size": os.path.getsize(output_file_path),
                         "type": "metadata"
-                    })
-        for granule in granules:
-            granule_id = granule['granuleId']
-            if append_output.get(granule_id, False):
-                granule['files'] += append_output[granule_id]['files']
-            
+                    }
+                    prefix = os.path.dirname(file_['filepath'])
+                    dmrpp_file['filepath'] = f'{prefix}/{dmrpp_file["name"]}'
+                    dmrpp_file['filename'] = f's3://{dmrpp_file["bucket"]}/{dmrpp_file["filepath"]}'
+                    dmrpp_files.append(dmrpp_file)
+                    self.upload_file(output_file_path, dmrpp_file['filename'])
+            granule['files'] += dmrpp_files
         return self.input
 
 
@@ -101,16 +95,14 @@ class DMRPPGenerator(Process):
     def dmrpp_generate(self, input_file):
         """
         """
-        if not match(f"{self.processing_regex}$", input_file):
-            return {}
         try:
             file_name = s3.download(input_file, path=self.path)
             cmd = f"get_dmrpp -b {self.path} -o {file_name}.dmrpp {os.path.basename(file_name)}"
-            self.run_command(cmd) 
-            return {'file_local_path': f"{file_name}.dmrpp", 's3_path': self.upload_file(f"{file_name}.dmrpp")}
+            self.run_command(cmd)
+            return f"{file_name}.dmrpp"
         except Exception as ex:
             self.logger.error(f"DMRPP error {ex}")
-        return {}
+            return None
 
 if __name__ == "__main__":
     DMRPPGenerator.cli()

--- a/dmrpp_generator/main.py
+++ b/dmrpp_generator/main.py
@@ -67,7 +67,7 @@ class DMRPPGenerator(Process):
                     dmrpp_file = {
                         "name": os.path.basename(output_file_path),
                         "path": self.config.get('fileStagingDir'),
-                        "url_path": file_['url_path'],
+                        "url_path": file_.get('url_path', self.config.get('fileStagingDir')),
                         "bucket": self.get_bucket(file_['filename'], collection.get('files', []),buckets)['name'],
                         "size": os.path.getsize(output_file_path),
                         "type": "metadata"


### PR DESCRIPTION
- changed s3 upload path to evaluated `url_path`: 
**before:** `s3://nsidc-cumulus-int-public/ATLAS/ATL03/003/{substring(file.name, 6, 10)}/{substring(file.name, 10,12)}/{substring(file.name, 12,14)}/ATL03_20181016190405_02770110_003_01.h5.dmrpp`
**after:** `s3://nsidc-cumulus-int-public/ATLAS/ATL03/003/2018/10/16/ATL03_20181016190405_02770110_003_01.h5.dmrpp`
- changed `upload_file` to take `uri` as second argument instead of getting `info` from parent `Process` class
- give `dmrpp_generate` a single responsibility
  - changed `dmrpp_generate` function to return name of file instead of a dict
  - moved `upload_file` call out of `dmrpp_generate`
  - moved `processing_regex` check out of `dmrpp_generate`
- streamlined `granule` loop in process function:
  - removed `append_output`
  - built up `granule['files']` to avoid second for loop
- @michaeljb, @schwabm