### PR TITLE
Make the processing_regex a configurable field in collection.meta

### DIFF
--- a/dmrpp_generator/main.py
+++ b/dmrpp_generator/main.py
@@ -12,7 +12,12 @@ class DMRPPGenerator(Process):
     """
 
     def __init__(self, **kwargs):
-        self.processing_regex = '.*\\.(((?i:(h|hdf)))(e)?5|nc(4)?)(\\.bz2|\\.gz|\\.Z)?'
+        self.processing_regex =  kwargs.get('config', {}) \
+                                    .get('collection', {}) \
+                                    .get('meta', {}) \
+                                    .get('dmrpp_processing_regex', '.*\\.(((?i:(h|hdf)))(e)?5|nc(4)?)(\\.bz2|\\.gz|\\.Z)?')
+
+
         super(DMRPPGenerator, self).__init__(**kwargs)
         self.path = self.path.rstrip('/') + "/"
 
@@ -107,7 +112,7 @@ class DMRPPGenerator(Process):
         options = dmrpp_options.get_dmrpp_option(dmrpp_meta=dmrpp_meta)
         return f"get_dmrpp {options} {input_path} -o {output_filename}.dmrpp {os.path.basename(output_filename)}"
 
-    
+
     def add_missing_files(self, dmrpp_meta, file_name):
         """
         """
@@ -145,4 +150,3 @@ if __name__ == "__main__":
     dmr = DMRPPGenerator(input = [], config = {})
     meta = {"options": [{"flag": "-s", "opt": "htp://localhost/config.conf", "download": "true"}, {"flag": "-M"}]}
     dmr.get_dmrpp_command(meta, dmr.path, "file_name.nc")
-

--- a/dmrpp_generator/main.py
+++ b/dmrpp_generator/main.py
@@ -12,7 +12,7 @@ class DMRPPGenerator(Process):
     """
 
     def __init__(self, **kwargs):
-        self.processing_regex = '.*(?<!BRW)\\.(((?i:(h|hdf)))(e)?5|nc(4)?)(\\.bz2|\\.gz|\\.Z)?'
+        self.processing_regex = '.*\\.(((?i:(h|hdf)))(e)?5|nc(4)?)(\\.bz2|\\.gz|\\.Z)?'
         super(DMRPPGenerator, self).__init__(**kwargs)
         self.path = self.path.rstrip('/') + "/"
 

--- a/dmrpp_generator/main.py
+++ b/dmrpp_generator/main.py
@@ -12,7 +12,7 @@ class DMRPPGenerator(Process):
     """
 
     def __init__(self, **kwargs):
-        self.processing_regex = '.*\\.(((?i:(h|hdf)))(e)?5|nc(4)?)(\\.bz2|\\.gz|\\.Z)?'
+        self.processing_regex = '.*(?<!BRW)\\.(((?i:(h|hdf)))(e)?5|nc(4)?)(\\.bz2|\\.gz|\\.Z)?'
         super(DMRPPGenerator, self).__init__(**kwargs)
         self.path = self.path.rstrip('/') + "/"
 


### PR DESCRIPTION
In some of NSIDC's collections, the granules include an HDF5 file containing browse imagery, ending in `BRW.h5`. We don't want dmrpp-generator to create a `.dmrpp` file for the `BRW.h5` file.

We are now using a fork of dmrpp-generator which changes the hard-coded regex to something that works for our purposes:

https://github.com/nsidc/dmrpp-file-generator-docker/commit/9fce5030a5f92f1082c0dbe331d85bf75b9c6605

For a more general solution, we felt it would be better if this regex could instead be configured in the collection JSON, so each DAAC can define their own regex for which files get a DMR++ file--if anyone else happens to have a `BRW.h5` file and they *do* want the DMR++ file, they could continue to use the default regex, while we set our own without impacting other DAACs.

[[NDCUM-464](https://bugs.earthdata.nasa.gov/browse/NDCUM-464)]