### PR TITLE
check workflow config for 'dmrpp' key if collection doesn't have it

### DIFF
--- a/dmrpp_generator/main.py
+++ b/dmrpp_generator/main.py
@@ -81,7 +81,7 @@ class DMRPPGenerator(Process):
         collection = self.config.get('collection')
         collection_files = collection.get('files', [])
         collection_meta = collection.get('meta', {})
-        dmrpp_meta = collection_meta.get('dmrpp', {})
+        dmrpp_meta = collection_meta.get('dmrpp', self.config.get('dmrpp', {}))
         buckets = self.config.get('buckets')
         granules = self.input['granules']
         self.processing_regex = dmrpp_meta.get('dmrpp_regex', self.processing_regex)


### PR DESCRIPTION
This allows putting the dmrpp config in the workflow to facilitate using the same config for many collections, and any collections that will be different can still have their own configuration.

As a quick test, I added a bit more logging in https://github.com/nsidc/dmrpp-file-generator-docker/commit/8fe1af621e4577607b0a097da3befe50b1e7fa1d to dump out the different possible dmrpp configs, and show which one that the code chooses. The CloudWatch screenshots show that the correct config is picked* (which is the third one logged in each of these screenshots).


*note: they also show some log messages being duplicated when I ran the next trial quickly; it seems that the underlying `Logger` instance from the `CumulusLogger` persists between runs, and when the `DMRPPGenerator` [instance is created](https://github.com/ghrcdaac/dmrpp-file-generator-docker/blob/v3.2.1.beta/dmrpp_generator/main.py#L25), the `CumulusLogger` creation grabs the same underlying `Logger`, and [adds another handler to it](https://github.com/nasa/cumulus-message-adapter-python/blob/v1.2.2/cumulus_logger.py#L95-L96) resulting in duplicate messages; I'm surprised the `Logger` manages to hang around, but I suspect this duplication could be removed by adding a check in `CumulusLogger.__init__` to only add a handler iff one isn't already present (edit to add: I have put in a PR to CMA to address this: https://github.com/nasa/cumulus-message-adapter-python/pull/43)

# Screenshots

## with no `dmrpp` key anywhere

![both empty](https://user-images.githubusercontent.com/1045173/147006889-f257babd-eacb-4b1a-a9f9-462280cde9e4.png)

## collection has `dmrpp` key

![just collection](https://user-images.githubusercontent.com/1045173/147006916-039a31d4-8b59-484a-8936-2c885db10aaa.png)

## workflow has `dmrpp` key

![just workflow](https://user-images.githubusercontent.com/1045173/147006933-b096ef79-60aa-40d1-9041-928884e9fca7.png)

## both collection and workflow have a `dmrpp` key, collection config is used

![both set](https://user-images.githubusercontent.com/1045173/147006944-ab1c5c4a-0fc0-4920-b070-604d27a1cb99.png)

## workflow has `dmrpp` key and value, collection has `dmrpp` key and value of `{}`

`"dmrpp": {}` in the collection overrides whatever `dmrpp` was in the workflow; note the difference between this case and the case where the collection simply doesn't have a `dmrpp` key and so the workflow config is used

![workflow with empty collection overriding](https://user-images.githubusercontent.com/1045173/147007774-f5fab2e7-3d83-41d6-9d9f-ab03803dd048.png)

