### PR TITLE
Remove dmrpp_processing_regex, merge dmrpp configs from workflows+collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ As with other variables in the JSON template file, the `dmrpp` config can be set
 ```
 
 If `dmrpp` configuration is set on the collection and in the workflow, any keys
-the collection's configuration will override those keys in the workflow's. This
-means, for example, if you want all collections processed with a given workflow
-to use the same `options` but different `dmrpp_regex`, the workflow config can
-set `options` and each collection can set `dmrpp_regex` to get the desired
-behavior.
+in the collection's configuration will override those keys in the
+workflow's. This means, for example, if you want all collections processed with
+a given workflow to use the same `options` but different `dmrpp_regex`, the
+workflow config can set `options` and each collection can set `dmrpp_regex` to
+get the desired behavior.
 
 # Supported get_dmrpp configuration
 ## Via env vars

--- a/README.md
+++ b/README.md
@@ -83,10 +83,12 @@ As with other variables in the JSON template file, the `dmrpp` config can be set
 }
 ```
 
-If `dmrpp` configuration is set on the collection and in the workflow, the
-collection's configuration will override the workflow's. In other words, the
-workflow's `dmrpp` configuration acts as a default which can be overridden by
-any collection.
+If `dmrpp` configuration is set on the collection and in the workflow, any keys
+the collection's configuration will override those keys in the workflow's. This
+means, for example, if you want all collections processed with a given workflow
+to use the same `options` but different `dmrpp_regex`, the workflow config can
+set `options` and each collection can set `dmrpp_regex` to get the desired
+behavior.
 
 # Supported get_dmrpp configuration
 ## Via env vars


### PR DESCRIPTION
* Previous behavior was to prefer config in collection over workflows; with new
  merging behavior, keys in collection will override keys in workflows. This
  allows, for example, the workflow config to set common `options` while the
  collection sets `dmrpp_regex` specific to that collection. In cases where
  configuration was set in the collection xor the workflow, the behavior is
  unchanged.

* set `self.processing_regex` just once in `__init__` instead of re-setting it
  in `process()`

* remove support for `collection.meta.dmrpp_processing_regex`; this was added in
  [#17][0] but was not the advertised way of setting the regex in release
  v3.1.0 (where `collection.meta.dmrpp.dmrpp_regex` was preferred)

* Fix typo in logs: 'reges' -> 'regex'

[0]: https://github.com/ghrcdaac/dmrpp-file-generator-docker/pull/17

-----

See also https://github.com/ghrcdaac/dmrpp-generator/pull/18