### PR TITLE
added acl bucket-owner-full-control when uploading files to s3

### DIFF
--- a/dmrpp_generator/main.py
+++ b/dmrpp_generator/main.py
@@ -85,7 +85,7 @@ class DMRPPGenerator(Process):
     def upload_file_to_s3(self, filename, uri):
         """ Upload a local file to s3 if collection payload provided """
         try:
-            return s3.upload(filename, uri, extra={})
+            return s3.upload(filename, uri, extra={"ACL": "bucket-owner-full-control"})
         except ClientError as cle:
             self.logger_to_cw.error(f"{self.dmrpp_version}: {cle}")
         except Exception as err:  # pylint: disable=broad-except


### PR DESCRIPTION
At PODAAC we have a use case where we run the dmrpp generator from a different aws account than our cumulus account. We would like the bucket owner to have full access control to the files that we upload when running the generator on different aws accounts. 